### PR TITLE
Removing mandatory href attribute from ProtocolRef element. OCECDR-4511

### DIFF
--- a/Licensee/pdq.dtd
+++ b/Licensee/pdq.dtd
@@ -282,8 +282,7 @@
 <!ATTLIST KeyPoint id CDATA #IMPLIED>
 
 <!ELEMENT ProtocolRef (#PCDATA)>
-<!ATTLIST ProtocolRef href CDATA #REQUIRED
-                      nct_id CDATA #REQUIRED>
+<!ATTLIST ProtocolRef nct_id CDATA #REQUIRED>
 
 <!ELEMENT ProtocolLink (#PCDATA)>
 <!ATTLIST ProtocolLink ref CDATA #REQUIRED>

--- a/Licensee/pdqCG.dtd
+++ b/Licensee/pdqCG.dtd
@@ -299,8 +299,7 @@
 <!ATTLIST KeyPoint id CDATA #IMPLIED>
 
 <!ELEMENT ProtocolRef (#PCDATA)>
-<!ATTLIST ProtocolRef href CDATA #REQUIRED
-                      nct_id CDATA #REQUIRED>
+<!ATTLIST ProtocolRef nct_id CDATA #REQUIRED>
 
 <!ELEMENT ProtocolLink (#PCDATA)>
 <!ATTLIST ProtocolLink ref CDATA #REQUIRED>


### PR DESCRIPTION
Updated DTD files.  No rush.